### PR TITLE
Implement TwoFactorProviderContext and EmailProvider

### DIFF
--- a/src/Contracts/TwoFactorUserContract.php
+++ b/src/Contracts/TwoFactorUserContract.php
@@ -21,7 +21,7 @@ interface TwoFactorUserContract
      */
     public function getTwoFactorProviders(): EloquentCollection;
 
-    public function getDefaultProviderType(): ?TwoFactorType;
+    public function getDefaultTwoFactorProvider(): ?TwoFactorType;
 
     /**
      * @return HasMany<TwoFactorUserProvider>

--- a/src/Models/Traits/HasTwoFactor.php
+++ b/src/Models/Traits/HasTwoFactor.php
@@ -45,7 +45,7 @@ trait HasTwoFactor
         return $this->twoFactorProviders;
     }
 
-    public function getDefaultProviderType(): ?TwoFactorType
+    public function getDefaultTwoFactorProvider(): ?TwoFactorType
     {
         $defaultProvider = config('two-factor-auth.defaults.provider');
 

--- a/src/Providers/EmailProvider.php
+++ b/src/Providers/EmailProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jauntin\TwoFactorAuth\Providers;
+
+use Closure;
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Support\Facades\Mail;
+use Jauntin\TwoFactorAuth\Contracts\TwoFactorMailable;
+use Jauntin\TwoFactorAuth\Contracts\TwoFactorUserContract;
+use Jauntin\TwoFactorAuth\Exception\ThrottledException;
+use Jauntin\TwoFactorAuth\VerificationCodeRepository;
+
+class EmailProvider implements TwoFactorProviderInterface
+{
+    public function __construct(
+        private readonly VerificationCodeRepository $codes,
+        private readonly TwoFactorMailable $mailable,
+    ) {}
+
+    /**
+     * @throws ThrottledException
+     */
+    public function sendVerificationCode(TwoFactorUserContract&User $user, ?Closure $callback = null): void
+    {
+        if ($this->codes->recentlyCreatedCode($user)) {
+            throw new ThrottledException('Too many verification code requests');
+        }
+
+        $verificationCode = $this->codes->create($user);
+
+        if ($callback) {
+            $callback($user, $verificationCode);
+        } else {
+            $this->sendEmail($user, $verificationCode);
+        }
+    }
+
+    public function validateVerificationCode(TwoFactorUserContract&User $user, string $verificationCode): bool
+    {
+        return $this->codes->exists($user, $verificationCode);
+    }
+
+    private function sendEmail(User&TwoFactorUserContract $user, string $verificationCode): void
+    {
+        Mail::to($user->getEmailForVerification())->queue($this->mailable->setVerificationCode($verificationCode));
+    }
+}

--- a/src/Providers/TwoFactorProviderContext.php
+++ b/src/Providers/TwoFactorProviderContext.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Jauntin\TwoFactorAuth\Providers;
+
+use Jauntin\TwoFactorAuth\Contracts\TwoFactorMailable;
+use Jauntin\TwoFactorAuth\Enums\TwoFactorType;
+use Jauntin\TwoFactorAuth\Exception\InvalidProviderException;
+use Jauntin\TwoFactorAuth\VerificationCodeRepository;
+
+class TwoFactorProviderContext
+{
+    public function __construct(private readonly VerificationCodeRepository $codes, private readonly TwoFactorMailable $mailable) {}
+
+    public function provider(TwoFactorType $type): TwoFactorProviderInterface
+    {
+        return match ($type) {
+            TwoFactorType::EMAIL => new EmailProvider($this->codes, $this->mailable),
+            default => throw new InvalidProviderException(sprintf('Two-factor provider "%s" is not supported.', $type->value)),
+        };
+    }
+}

--- a/src/Providers/TwoFactorProviderInterface.php
+++ b/src/Providers/TwoFactorProviderInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Jauntin\TwoFactorAuth\Providers;
+
+use Closure;
+use Illuminate\Foundation\Auth\User;
+use Jauntin\TwoFactorAuth\Contracts\TwoFactorUserContract;
+
+interface TwoFactorProviderInterface
+{
+    public function sendVerificationCode(User&TwoFactorUserContract $user, ?Closure $callback = null): void;
+
+    public function validateVerificationCode(User&TwoFactorUserContract $user, string $verificationCode): bool;
+}

--- a/src/TwoFactorAuthServiceProvider.php
+++ b/src/TwoFactorAuthServiceProvider.php
@@ -51,10 +51,9 @@ final class TwoFactorAuthServiceProvider extends ServiceProvider
         });
     }
 
-
     private function registerTwoFactorProviderContext(): void
     {
-        $this->app->bind(TwoFactorMailable::class, $this->app['config']['two-factor-auth.providers.email.mailable']);
+        $this->app->bind(TwoFactorMailable::class, config('two-factor-auth.providers.email.mailable'));
         $this->app->singleton(TwoFactorProviderContext::class, function (Container $container) {
             return new TwoFactorProviderContext(
                 $container->make(VerificationCodeRepository::class),

--- a/src/TwoFactorBroker.php
+++ b/src/TwoFactorBroker.php
@@ -121,6 +121,14 @@ class TwoFactorBroker
     }
 
     /**
+     * Determine if a verification code record exists for user and is not expired.
+     */
+    public function existsNotExpired(User&TwoFactorUserContract $user): bool
+    {
+        return $this->codes->existsNotExpired($user);
+    }
+
+    /**
      * Validate a password reset for the given credentials.
      *
      * @throws InvalidCredentialsException|InvalidVerificationCodeException|InvalidProviderException

--- a/src/VerificationCodeRepository.php
+++ b/src/VerificationCodeRepository.php
@@ -47,6 +47,18 @@ class VerificationCodeRepository
     }
 
     /**
+     * Determine if a verification code record exists for user and is not expired.
+     */
+    public function existsNotExpired(User&TwoFactorUserContract $user): bool
+    {
+        $expiredAt = Carbon::now()->subMinutes($this->expire);
+
+        return TwoFactorVerificationCode::where('user_id', $user->getAuthIdentifier())
+            ->where('created_at', '>=', $expiredAt)
+            ->exists();
+    }
+
+    /**
      * Determine if the verification code has expired.
      */
     protected function codeExpired(Carbon $createdAt): bool

--- a/src/VerificationCodeRepository.php
+++ b/src/VerificationCodeRepository.php
@@ -61,13 +61,13 @@ class VerificationCodeRepository
     {
         $record = TwoFactorVerificationCode::where('user_id', $user->getAuthIdentifier())->first();
 
-        return $record && $this->tokenRecentlyCreated($record->created_at);
+        return $record && $this->verificationCodeRecentlyCreated($record->created_at);
     }
 
     /**
      * Determine if the verification code record was recently created.
      */
-    protected function tokenRecentlyCreated(Carbon $createdAt): bool
+    protected function verificationCodeRecentlyCreated(Carbon $createdAt): bool
     {
         if ($this->throttle <= 0) {
             return false;

--- a/tests/Unit/Providers/EmailProviderTest.php
+++ b/tests/Unit/Providers/EmailProviderTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Unit\Providers;
+
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Support\Facades\Mail;
+use Jauntin\TwoFactorAuth\Contracts\TwoFactorMailable;
+use Jauntin\TwoFactorAuth\Contracts\TwoFactorUserContract;
+use Jauntin\TwoFactorAuth\Exception\ThrottledException;
+use Jauntin\TwoFactorAuth\Notification\TwoFactorVerification;
+use Jauntin\TwoFactorAuth\Providers\EmailProvider;
+use Jauntin\TwoFactorAuth\VerificationCodeRepository;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Orchestra\Testbench\TestCase;
+
+class EmailProviderTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Mail::fake();
+        $this->codes = Mockery::mock(VerificationCodeRepository::class);
+        $this->provider = new EmailProvider($this->codes, new TwoFactorVerification);
+
+        $this->user = Mockery::mock(User::class, TwoFactorUserContract::class);
+        $this->user->shouldReceive('getAuthIdentifier')->andReturn(1);
+        $this->user->shouldReceive('getEmailForVerification')->andReturn('test@example.com');
+    }
+
+    public function testSendVerificationCodeSuccessfully()
+    {
+        $this->codes->expects('recentlyCreatedCode')->with($this->user)->andReturnFalse()->once();
+        $this->codes->shouldReceive('create')->with($this->user)->andReturn('123456');
+
+        $this->provider->sendVerificationCode($this->user);
+
+        Mail::assertQueued(function (TwoFactorMailable $mailable) {
+            return $mailable->to[0]['address'] === 'test@example.com';
+        });
+    }
+
+    public function testSendVerificationCodeWithThrottleException()
+    {
+        $this->expectException(ThrottledException::class);
+        $this->expectExceptionMessage('Too many verification code requests');
+
+        $this->codes->shouldReceive('recentlyCreatedCode')->with($this->user)->andReturn(true);
+
+        $this->provider->sendVerificationCode($this->user);
+    }
+
+    public function testSendVerificationCodeWithCallback()
+    {
+        $this->codes->shouldReceive('recentlyCreatedCode')->with($this->user)->andReturn(false);
+        $this->codes->shouldReceive('create')->with($this->user)->andReturn('123456');
+
+        $callback = function (User $user, string $verificationCode) {
+            $this->assertSame($this->user, $user);
+            $this->assertEquals('123456', $verificationCode);
+        };
+        $callback->bindTo($this);
+        $this->provider->sendVerificationCode($this->user, $callback);
+
+        Mail::assertNotQueued(TwoFactorMailable::class);
+    }
+
+    public function testValidateVerificationCodeSuccessfully()
+    {
+        $this->codes->shouldReceive('exists')->with($this->user, '123456')->andReturn(true);
+
+        $isValid = $this->provider->validateVerificationCode($this->user, '123456');
+
+        $this->assertTrue($isValid);
+    }
+
+    public function testValidateVerificationCodeFails()
+    {
+        $this->codes->shouldReceive('exists')->with($this->user, 'wrong_code')->andReturn(false);
+
+        $isValid = $this->provider->validateVerificationCode($this->user, 'wrong_code');
+
+        $this->assertFalse($isValid);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Mockery::close();
+    }
+}

--- a/tests/Unit/Providers/TwoFactorProviderContextTest.php
+++ b/tests/Unit/Providers/TwoFactorProviderContextTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit\Providers;
+
+use Jauntin\TwoFactorAuth\Contracts\TwoFactorMailable;
+use Jauntin\TwoFactorAuth\Enums\TwoFactorType;
+use Jauntin\TwoFactorAuth\Exception\InvalidProviderException;
+use Jauntin\TwoFactorAuth\Providers\EmailProvider;
+use Jauntin\TwoFactorAuth\Providers\TwoFactorProviderContext;
+use Jauntin\TwoFactorAuth\VerificationCodeRepository;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Orchestra\Testbench\TestCase;
+
+class TwoFactorProviderContextTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->codes = Mockery::mock(VerificationCodeRepository::class);
+        $this->mailable = Mockery::mock(TwoFactorMailable::class);
+
+        $this->context = new TwoFactorProviderContext($this->codes, $this->mailable);
+    }
+
+    public function testProviderReturnsEmailProvider()
+    {
+        $provider = $this->context->provider(TwoFactorType::EMAIL);
+
+        $this->assertInstanceOf(EmailProvider::class, $provider);
+    }
+
+    public function testProviderThrowsInvalidProviderException()
+    {
+        $this->expectException(InvalidProviderException::class);
+        $this->expectExceptionMessage('Two-factor provider "sms" is not supported.');
+
+        $this->context->provider(TwoFactorType::SMS);
+    }
+}

--- a/tests/Unit/TwoFactorBrokerTest.php
+++ b/tests/Unit/TwoFactorBrokerTest.php
@@ -455,4 +455,22 @@ class TwoFactorBrokerTest extends TestCase
 
         $this->assertTrue($broker->hasRecentlyCreatedCode($user));
     }
+
+    public function testExistsNotExpired()
+    {
+        $user = Mockery::mock(User::class, TwoFactorUserContract::class);
+
+        $codes = Mockery::mock(VerificationCodeRepository::class);
+        $codes->expects('existsNotExpired')->with($user)->once()->andReturnTrue();
+
+        $userProvider = Mockery::mock(UserProvider::class);
+        $userProvider->shouldNotReceive('retrieveByCredentials');
+
+        $context = Mockery::mock(TwoFactorProviderContext::class);
+        $context->shouldNotReceive('provider');
+
+        $broker = new TwoFactorBroker($codes, $userProvider, $context);
+
+        $this->assertTrue($broker->existsNotExpired($user));
+    }
 }


### PR DESCRIPTION
### What does this PR address?

For separation of concerns added `TwoFactorProviderInterface`. Its implementations must be responsible for sending and validating 2FA codes for different 2FA providers. 

### How does this PR address the issue?

1. Added `TwoFactorProviderContext` class for resolving implementations of `TwoFactorProviderInterface` classes.
2. Added `EmailProvider` class as implementation of `TwoFactorProviderInterface` for 2FA via email
3. Added `hasRecentlyCreatedCode` to `TwoFactorBroker` to cleanup Gatherguard integration
4. Wrote tests

### Pre-merge Checklist

- [ ] PR has been linked to an issue
- [ ] Tests created or updated as necessary
- [ ] Author has manually tested the update
- [ ] Reviewer has manually tested the update
