### PR TITLE
Remove unique index from code column and change hash algorithm

### DIFF
--- a/database/migrations/2024_10_09_000000_create_two_factor_tables.php
+++ b/database/migrations/2024_10_09_000000_create_two_factor_tables.php
@@ -20,7 +20,7 @@ return new class extends Migration
 
         Schema::create('two_factor_verification_codes', function (Blueprint $table) {
             $table->foreignId('user_id');
-            $table->string('code')->unique();
+            $table->string('code');
             $table->timestamp('created_at');
             $table->foreign('user_id')->references('id')->on('users');
         });

--- a/src/TwoFactorAuthServiceProvider.php
+++ b/src/TwoFactorAuthServiceProvider.php
@@ -4,6 +4,7 @@ namespace Jauntin\TwoFactorAuth;
 
 use Illuminate\Auth\CreatesUserProviders;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Hashing\Hasher;
 use Illuminate\Support\ServiceProvider;
 use Jauntin\TwoFactorAuth\Contracts\TwoFactorMailable;
 use Jauntin\TwoFactorAuth\Providers\TwoFactorProviderContext;
@@ -37,13 +38,8 @@ final class TwoFactorAuthServiceProvider extends ServiceProvider
     private function registerVerificationCodeRepository(): void
     {
         $this->app->singleton(VerificationCodeRepository::class, function (Container $container) {
-            $key = $container['config']['app.key'];
-            if (str_starts_with($key, 'base64:')) {
-                $key = base64_decode(substr($key, 7));
-            }
-
             return new VerificationCodeRepository(
-                $key,
+                $container->make(Hasher::class),
                 $container['config']['two-factor-auth.pattern'],
                 $container['config']['two-factor-auth.expire'],
                 $container['config']['two-factor-auth.throttle'],


### PR DESCRIPTION
### What does this PR address?

Remove unique index from `two_factor_verification_codes.code` column to prevent unique value exceptions. Change hash algorithm to safer one

### How does this PR address the issue?

- Updated migration
- Update `VerificationCodeRepository` to have `Hasher` contract implementation for creating hash
- Update tests

### Pre-merge Checklist

- [ ] PR has been linked to an issue
- [ ] Tests created or updated as necessary
- [ ] Author has manually tested the update
- [ ] Reviewer has manually tested the update
